### PR TITLE
Add Tx Success Verification before Success notice

### DIFF
--- a/src/components/NFTUpdateForm.vue
+++ b/src/components/NFTUpdateForm.vue
@@ -93,7 +93,7 @@ import { NFTGet } from '@/common/NFTget';
 import { NFTUpdate } from '@/common/NFTupdate';
 import useModal from '@/composables/modal';
 import ExplorerLink from '@/components/ExplorerLink.vue';
-import { objectOneInsideObjectTwo } from '@/common/helpers/util';
+import { objectOneInsideObjectTwo, isTransactionComplete } from '@/common/helpers/util';
 import ContentTooltipMetadata from '@/components/content/tooltip/ContentTooltipMetadata.vue';
 import StdNotifications from '@/components/StdNotifications.vue';
 import { DEFAULTS } from '@/globals';
@@ -178,9 +178,11 @@ export default defineComponent({
         primarySaleHappened.value as any // null-undefined conflict
       )
         .then(async (result: string) => {
-          txId.value = result;
-          isLoading.value = false;
-          await fetchUpdatedNFT();
+          if(await isTransactionComplete(result)) {
+            txId.value = result;
+            isLoading.value = false;
+            await fetchUpdatedNFT();
+          }
         })
         .catch((e) => {
           setError(e);


### PR DESCRIPTION
Issue: I used NFT Update a couple times today while Solana was congested and got success notifications when the transaction actually timed out on the network. 

Solution: added a simple function to check the transaction status using getSignatureStatus (https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getSignatureStatus). The function will run for a set period and then proceed with FetchNFT/Success notification. 

I suspect there are other components where this could be used, but just ran with it on NFTUpdate for the moment. Happy to chat on discord. AMilz#7564.